### PR TITLE
feat: resolve remaining UX issues for non-technical workflow

### DIFF
--- a/AIEF/context/experience/INDEX.md
+++ b/AIEF/context/experience/INDEX.md
@@ -33,6 +33,14 @@
    - 修复：统一入口为 `python forge.py test`，并接入四平台回归脚本
    - 回归：本地执行 `python forge.py test`，CI 统一调用同一命令
 
+6. 非技术用户流程缺少可持续验收
+   - 触发：CLI 在持续迭代后，非技术路径（首次安装/首次生成/失败恢复）容易退化
+   - 修复：新增 `scripts/nontech_acceptance_regression.py`，覆盖 5 条验收用例；CI 至少执行核心 2 条（`--core-only`）
+   - 回归：
+     - CI：`python forge.py test`（内部触发 `nontech_acceptance_regression.py --core-only`）
+     - 发版前：手动执行 `python3 scripts/nontech_acceptance_regression.py` 全量验收
+   - 更新频率：每次修改 CLI 交互/错误提示/模板输入后，必须同步更新该验收脚本
+
 ## 待补充
 
 - 为四平台回归补充更真实的浏览器 E2E（当前以最小可执行回归为主）

--- a/README.md
+++ b/README.md
@@ -26,6 +26,30 @@ python forge.py test
 python forge.py generate -p xiaohongshu -t route_guide -k "莫干山徒步" -s
 ```
 
+## 5分钟上手（非技术）
+
+如果你只想尽快出一篇可发布内容，按下面做：
+
+```bash
+# 1) 启动向导（推荐）
+python forge.py wizard
+
+# 2) 只要先填关键词，其它可选项可以直接跳过
+# 3) 生成后按提示选择：复制 / 保存 / 发布
+```
+
+从关键词到发布的完整示例：
+
+```bash
+# A. 生成并保存
+python forge.py generate -p xiaohongshu -t route_guide -k "莫干山徒步" -s
+
+# B. 基于同样关键词直接发布（半自动）
+python forge.py generate -p xiaohongshu -t route_guide -k "莫干山徒步" --publish
+```
+
+出错时看这里：`README.md#常见错误与修复`
+
 ## 使用方式
 
 ### 命令行生成
@@ -90,6 +114,21 @@ python forge.py interactive
 python forge.py scenario -c outdoor -n hiking_trip -k "天目山徒步" \
   -m '{"distance": "12公里", "duration": "5小时"}'
 ```
+
+## 常见错误与修复
+
+- 关键词缺失
+  - 现象：提示“缺少关键词”
+  - 修复：补 `-k "关键词"` 或在素材 JSON 中补 `keywords`
+  - 示例：`python forge.py generate -p xhs -t 攻略 -k "莫干山徒步"`
+- 素材 JSON 解析失败
+  - 现象：提示“素材文件 JSON 格式错误”
+  - 修复：检查逗号、引号、括号是否配对
+  - 示例：`python forge.py generate -p xhs -t 攻略 -m data/materials/demo.json`
+- 发布失败
+  - 现象：发布阶段出现错误码（如 `LOGIN_REQUIRED` / `PUBLISH_BLOCKED`）
+  - 修复：按“建议动作”先处理登录、内容长度、标签数量后重试
+  - 示例：`python forge.py generate -p zh -t 问答 -k "徒步装备" --publish`
 
 ## 协作与发布流程（强制）
 

--- a/forge.py
+++ b/forge.py
@@ -223,6 +223,96 @@ def load_materials(materials_arg: str) -> dict:
         return {}
 
 
+def _build_publish_precheck(platform: str, publish_content, has_auth: bool):
+    length_limits = {
+        "xiaohongshu": 1000,
+        "wechat": 20000,
+        "zhihu": 50000,
+        "toutiao": 2000,
+    }
+    tag_limits = {
+        "xiaohongshu": 10,
+        "wechat": 5,
+        "zhihu": 5,
+        "toutiao": 5,
+    }
+
+    checks = []
+    blockers = []
+
+    checks.append(
+        {
+            "item": "登录态",
+            "ok": has_auth,
+            "detail": "已检测到登录态"
+            if has_auth
+            else "未检测到登录态，发布时会要求登录",
+        }
+    )
+
+    content_len = len((publish_content.content or "").strip())
+    length_limit = length_limits.get(platform, 50000)
+    len_ok = 0 < content_len <= length_limit
+    checks.append(
+        {
+            "item": "正文长度",
+            "ok": len_ok,
+            "detail": f"{content_len}/{length_limit} 字",
+        }
+    )
+    if not len_ok:
+        blockers.append(f"正文长度不合法（当前 {content_len} 字）")
+
+    tags = publish_content.tags or []
+    tag_limit = tag_limits.get(platform, 5)
+    tag_ok = len(tags) <= tag_limit
+    checks.append(
+        {
+            "item": "标签数量",
+            "ok": tag_ok,
+            "detail": f"{len(tags)}/{tag_limit} 个",
+        }
+    )
+
+    image_count = len(publish_content.images or [])
+    if platform == "xiaohongshu":
+        checks.append(
+            {
+                "item": "图片素材",
+                "ok": image_count > 0,
+                "detail": (
+                    f"已提供 {image_count} 张"
+                    if image_count > 0
+                    else "未提供图片，将自动生成占位图"
+                ),
+            }
+        )
+    else:
+        checks.append(
+            {
+                "item": "图片素材",
+                "ok": True,
+                "detail": f"已提供 {image_count} 张（可选）",
+            }
+        )
+
+    return checks, blockers
+
+
+def _publish_next_step(result) -> str:
+    if result.next_action:
+        return result.next_action
+
+    fallback = {
+        "LOGIN_REQUIRED": "请先完成平台登录，再重试发布。",
+        "EDITOR_NOT_FOUND": "刷新页面并重试；仍失败请切换手动发布。",
+        "PUBLISH_BLOCKED": "检查标题/正文/标签是否符合平台规则。",
+        "UPLOAD_FAILED": "检查图片路径与格式后重试。",
+        "USER_CANCELLED": "这是主动取消；需要发布时重新执行即可。",
+    }
+    return fallback.get(result.error_code, "请查看错误详情并重试。")
+
+
 def publish_results(results, platforms, auto_confirm=False):
     """
     将生成的内容发布到各平台
@@ -232,7 +322,7 @@ def publish_results(results, platforms, auto_confirm=False):
         platforms: 要发布的平台列表
         auto_confirm: 是否自动确认发布
     """
-    from publisher.base import PublishContent
+    from publisher.base import PublishContent, build_publish_failure
     from publisher.xiaohongshu import XiaohongshuPublisher
     from publisher.zhihu import ZhihuPublisher
     from publisher.wechat import WechatPublisher
@@ -293,16 +383,40 @@ def publish_results(results, platforms, auto_confirm=False):
                 print(
                     f"  标签: {', '.join(publish_content.tags[:5])}{'...' if len(publish_content.tags) > 5 else ''}"
                 )
-            print("─" * 60)
-
             publisher = publisher_cls(headless=False, auto_confirm=auto_confirm)
-            result = publisher.publish(publish_content)
+            checks, blockers = _build_publish_precheck(
+                platform=platform,
+                publish_content=publish_content,
+                has_auth=publisher.auth_file.exists(),
+            )
+
+            print("  【发布前检查】")
+            for check in checks:
+                icon = "✓" if check["ok"] else "⚠"
+                print(f"    {icon} {check['item']}: {check['detail']}")
+
+            if blockers:
+                result = build_publish_failure(
+                    platform=platform_name,
+                    code="CONTENT_INVALID",
+                    message="发布前检查未通过",
+                    error="；".join(blockers),
+                    details={"blockers": blockers},
+                )
+            else:
+                result = publisher.publish(publish_content)
+
             all_publish_results.append(result)
 
             status = "✓ 成功" if result.success else "✗ 失败"
             print(f"  {status}: {result.message}")
+            if result.error_code:
+                print(f"    错误码: {result.error_code}")
             if result.error:
                 print(f"    错误: {result.error}")
+            if not result.success:
+                print(f"    建议动作: {_publish_next_step(result)}")
+            print("─" * 60)
 
     # 发布结果汇总
     print(f"\n{'=' * 60}")
@@ -310,8 +424,16 @@ def publish_results(results, platforms, auto_confirm=False):
     for r in all_publish_results:
         icon = "✓" if r.success else "✗"
         print(f"  {icon} {r.platform}: {r.message}")
+        if r.error_code:
+            print(f"    错误码: {r.error_code}")
+        if r.url:
+            print(f"    链接: {r.url}")
+        if not r.success:
+            print(f"    下一步: {_publish_next_step(r)}")
     success_count = sum(1 for r in all_publish_results if r.success)
     print(f"\n  成功: {success_count}/{len(all_publish_results)}")
+    if success_count != len(all_publish_results):
+        print("  提示: 建议先修复失败项，再进行下一轮发布。")
     print("=" * 60)
 
 
@@ -582,6 +704,19 @@ def cmd_check(args):
     print(report)
 
 
+def _input_optional(prompt: str, example: str = "", default: str = "") -> str:
+    hint_parts = []
+    if default:
+        hint_parts.append(f"默认: {default}")
+    if example:
+        hint_parts.append(f"示例: {example}")
+    hint = f"（{'；'.join(hint_parts)}；回车跳过）" if hint_parts else "（回车跳过）"
+    raw = input(f"{prompt}{hint}: ").strip()
+    if not raw:
+        return default
+    return raw
+
+
 def cmd_interactive(args):
     """交互式模式"""
     from generator.content_generator import ContentGenerator
@@ -599,14 +734,14 @@ def cmd_interactive(args):
         "4": ("toutiao", "今日头条"),
     }
 
-    print("\n选择目标平台:")
+    print("\n【必填项】1/3：选择目标平台")
     for key, (_, name) in platforms.items():
         print(f"  {key}. {name}")
 
-    choice = input("\n请输入数字 (1-4): ").strip()
+    choice = input("\n请输入数字 (1-4，默认 1): ").strip() or "1"
     if choice not in platforms:
-        print("无效选择")
-        return
+        print("无效选择，默认使用 1。")
+        choice = "1"
 
     platform, platform_name = platforms[choice]
 
@@ -635,14 +770,14 @@ def cmd_interactive(args):
         },
     }
 
-    print(f"\n选择 {platform_name} 内容类型:")
+    print(f"\n【必填项】2/3：选择 {platform_name} 内容类型")
     for key, (_, name) in content_types[platform].items():
         print(f"  {key}. {name}")
 
-    choice = input("\n请输入数字: ").strip()
+    choice = input("\n请输入数字（默认 1）: ").strip() or "1"
     if choice not in content_types[platform]:
-        print("无效选择")
-        return
+        print("无效选择，默认使用 1。")
+        choice = "1"
 
     content_type, type_name = content_types[platform][choice]
 
@@ -652,32 +787,39 @@ def cmd_interactive(args):
 
     materials = {}
 
-    keywords = input("关键词 (必填): ").strip()
-    if not keywords:
-        print("关键词不能为空")
-        return
+    print("\n【必填项】3/3：关键词")
+    keywords = _input_non_empty("关键词（示例：莫干山徒步）: ")
     materials["keywords"] = keywords
 
-    # 根据内容类型收集更多信息
-    if content_type in ["route_guide", "experience_share"]:
-        materials["location"] = input("地点: ").strip() or None
-        materials["distance"] = input("距离: ").strip() or None
-        materials["duration"] = input("用时: ").strip() or None
-        materials["highlight"] = input("亮点: ").strip() or None
-        materials["regret"] = input("遗憾/教训: ").strip() or None
+    print("\n【可选项】")
+    quick_skip = input("输入 s 一键跳过所有可选项，直接回车继续填写: ").strip().lower()
+    if quick_skip != "s":
+        if content_type in ["route_guide", "experience_share"]:
+            materials["location"] = _input_optional("地点", example="杭州西湖") or None
+            materials["distance"] = _input_optional("距离", example="12公里") or None
+            materials["duration"] = _input_optional("用时", example="4小时") or None
+            materials["highlight"] = (
+                _input_optional("亮点", example="日落观景平台") or None
+            )
+            materials["regret"] = (
+                _input_optional("遗憾/教训", example="后半段补给点少") or None
+            )
+        elif content_type == "gear_review":
+            materials["gear_name"] = (
+                _input_optional("装备名称", example="登山杖") or None
+            )
+            materials["brand"] = (
+                _input_optional("品牌", example="Black Diamond") or None
+            )
+            materials["price"] = _input_optional("价格", example="299元") or None
+        elif content_type in ["question_answer", "experience_sharing"]:
+            materials["question"] = (
+                _input_optional("问题", example="新手徒步鞋怎么选？") or None
+            )
 
-    elif content_type == "gear_review":
-        materials["gear_name"] = input("装备名称: ").strip() or None
-        materials["brand"] = input("品牌: ").strip() or None
-        materials["price"] = input("价格: ").strip() or None
-
-    elif content_type in ["question_answer", "experience_sharing"]:
-        materials["question"] = input("问题: ").strip() or None
-
-    # 语音记录
-    transcript = input("语音记录 (可选，直接回车跳过): ").strip()
-    if transcript:
-        materials["transcript"] = transcript
+        transcript = _input_optional("语音记录", example="我这次路线是...")
+        if transcript:
+            materials["transcript"] = transcript
 
     # 清理空值
     materials = {k: v for k, v in materials.items() if v}
@@ -703,14 +845,14 @@ def cmd_interactive(args):
         print(report)
 
         # 询问是否复制
-        copy_choice = input("\n复制到剪贴板? (y/n): ").strip().lower()
+        copy_choice = input("\n复制到剪贴板? (Y/n): ").strip().lower() or "y"
         if copy_choice == "y":
             copyable = format_copyable_content(result)
             if copy_to_clipboard(copyable):
                 print("✓ 已复制到剪贴板")
 
         # 询问是否保存
-        save = input("保存到文件? (y/n): ").strip().lower()
+        save = input("保存到文件? (Y/n): ").strip().lower() or "y"
         if save == "y":
             output_dir = Path(__file__).parent / "data" / "generated"
             output_dir.mkdir(parents=True, exist_ok=True)
@@ -927,22 +1069,24 @@ def cmd_test(args):
     # 测试回归脚本
     print("\n6. 测试回归脚本...")
     script_dir = Path(__file__).parent / "scripts"
-    regression_scripts = [
-        script_dir / "xiaohongshu_regression.py",
-        script_dir / "wechat_regression.py",
-        script_dir / "toutiao_regression.py",
-        script_dir / "zhihu_format_regression.py",
-        script_dir / "zhihu_e2e_regression.py",
+    regression_commands = [
+        (script_dir / "xiaohongshu_regression.py", []),
+        (script_dir / "wechat_regression.py", []),
+        (script_dir / "toutiao_regression.py", []),
+        (script_dir / "zhihu_format_regression.py", []),
+        (script_dir / "zhihu_e2e_regression.py", []),
+        (script_dir / "nontech_acceptance_regression.py", ["--core-only"]),
     ]
 
-    for script in regression_scripts:
+    for script, extra_args in regression_commands:
         if not script.exists():
             print(f"   ⚠ 跳过（文件不存在）: {script.name}")
             continue
 
-        print(f"   → 运行: {script.name}")
+        cmd_suffix = " " + " ".join(extra_args) if extra_args else ""
+        print(f"   → 运行: {script.name}{cmd_suffix}")
         result = subprocess.run(
-            [sys.executable, str(script)], capture_output=True, text=True
+            [sys.executable, str(script), *extra_args], capture_output=True, text=True
         )
         if result.returncode == 0:
             print(f"   ✓ 通过: {script.name}")

--- a/scripts/nontech_acceptance_regression.py
+++ b/scripts/nontech_acceptance_regression.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""非技术用户验收回归脚本。"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FORGE = ROOT / "forge.py"
+
+
+def _run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def case_first_install_assets() -> tuple[bool, str]:
+    requirements = (ROOT / "requirements.txt").exists()
+    env_example = (ROOT / ".env.example").exists()
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    has_nontech_guide = "5分钟上手（非技术）" in readme
+    ok = requirements and env_example and has_nontech_guide
+    detail = "requirements/.env.example/README 非技术入口已就绪"
+    return ok, detail
+
+
+def case_first_generate_discovery() -> tuple[bool, str]:
+    result = _run([sys.executable, str(FORGE), "list"])
+    ok = (
+        result.returncode == 0
+        and "【平台】" in result.stdout
+        and "【内容类型】" in result.stdout
+    )
+    return ok, "list 命令可见平台与类型"
+
+
+def case_templates_ready() -> tuple[bool, str]:
+    template_dir = ROOT / "config" / "material_templates"
+    names = [
+        "route_guide.json",
+        "gear_review.json",
+        "question_answer.json",
+        "project_promotion.json",
+    ]
+    for name in names:
+        file_path = template_dir / name
+        if not file_path.exists():
+            return False, f"模板缺失: {name}"
+        data = json.loads(file_path.read_text(encoding="utf-8"))
+        if "keywords" not in data:
+            return False, f"模板缺少 keywords: {name}"
+    return True, "4 类模板均可直接填写"
+
+
+def case_save_publish_flags() -> tuple[bool, str]:
+    result = _run([sys.executable, str(FORGE), "generate", "-h"])
+    stdout = result.stdout
+    ok = result.returncode == 0 and "-s, --save" in stdout and "--publish" in stdout
+    return ok, "generate 帮助包含保存与发布参数"
+
+
+def case_failure_recovery_message() -> tuple[bool, str]:
+    result = _run(
+        [
+            sys.executable,
+            str(FORGE),
+            "generate",
+            "-p",
+            "bad_platform",
+            "-t",
+            "攻略",
+            "-k",
+            "测试",
+        ]
+    )
+    merged = (result.stdout or "") + (result.stderr or "")
+    ok = (
+        result.returncode != 0
+        and "错误:" in merged
+        and "修复:" in merged
+        and "示例:" in merged
+    )
+    return ok, "失败场景输出三段式修复提示"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="非技术用户验收回归")
+    parser.add_argument("--core-only", action="store_true", help="只跑核心 2 条用例")
+    args = parser.parse_args()
+
+    all_cases = [
+        ("首次安装", case_first_install_assets),
+        ("首次生成", case_first_generate_discovery),
+        ("模板输入", case_templates_ready),
+        ("保存发布", case_save_publish_flags),
+        ("失败恢复", case_failure_recovery_message),
+    ]
+    cases = all_cases[:2] if args.core_only else all_cases
+
+    print("=" * 50)
+    print("非技术用户验收回归")
+    print("=" * 50)
+
+    failed = 0
+    for idx, (name, fn) in enumerate(cases, 1):
+        ok, detail = fn()
+        status = "✓" if ok else "✗"
+        print(f"{idx}. {status} {name}: {detail}")
+        if not ok:
+            failed += 1
+
+    print("-" * 50)
+    print(f"通过: {len(cases) - failed}/{len(cases)}")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/publisher/base.py
+++ b/src/publisher/base.py
@@ -38,6 +38,42 @@ class PublishResult:
     url: str = ""  # 发布后的链接
     message: str = ""
     error: str = ""
+    error_code: str = ""
+    next_action: str = ""
+    details: Dict[str, Any] = field(default_factory=dict)
+
+
+PUBLISH_ERROR_ACTIONS: Dict[str, str] = {
+    "LOGIN_REQUIRED": "先在浏览器完成登录，再重新执行发布。",
+    "EDITOR_NOT_FOUND": "刷新页面后重新进入发布页，确认进入正确编辑器。",
+    "PUBLISH_BLOCKED": "检查标题/正文/标签是否符合平台限制后重试。",
+    "UPLOAD_FAILED": "确认图片文件存在且格式可用，再重试上传。",
+    "NETWORK_ERROR": "检查网络连接后重试。",
+    "USER_CANCELLED": "这是主动取消操作；如需发布，请重新执行并确认。",
+    "CONTENT_INVALID": "补全必填内容后重试发布。",
+    "PUBLISH_EXCEPTION": "查看错误详情并按平台提示修复后重试。",
+    "UNKNOWN": "重试一次；若仍失败，请切换手动发布。",
+}
+
+
+def build_publish_failure(
+    platform: str,
+    code: str,
+    message: str,
+    error: str = "",
+    url: str = "",
+    details: Optional[Dict[str, Any]] = None,
+) -> PublishResult:
+    return PublishResult(
+        platform=platform,
+        success=False,
+        url=url,
+        message=message,
+        error=error,
+        error_code=code,
+        next_action=PUBLISH_ERROR_ACTIONS.get(code, PUBLISH_ERROR_ACTIONS["UNKNOWN"]),
+        details=details or {},
+    )
 
 
 class BasePublisher(ABC):
@@ -161,11 +197,11 @@ class BasePublisher(ABC):
                 result = self._do_publish(content)
                 return result
             except Exception as e:
-                return PublishResult(
+                return build_publish_failure(
                     platform=self.PLATFORM_NAME,
-                    success=False,
+                    code="PUBLISH_EXCEPTION",
+                    message="发布失败：出现未处理异常",
                     error=str(e),
-                    message=f"发布失败: {e}",
                 )
             finally:
                 if self.context:

--- a/src/publisher/toutiao.py
+++ b/src/publisher/toutiao.py
@@ -98,4 +98,6 @@ class ToutiaoPublisher(BasePublisher):
             platform=self.PLATFORM_NAME,
             success=False,
             message="用户跳过发布",
+            error_code="USER_CANCELLED",
+            next_action="这是主动取消操作；如需发布，请重新执行并确认。",
         )

--- a/src/publisher/wechat.py
+++ b/src/publisher/wechat.py
@@ -151,4 +151,6 @@ class WechatPublisher(BasePublisher):
             platform=self.PLATFORM_NAME,
             success=False,
             message="用户跳过发布",
+            error_code="USER_CANCELLED",
+            next_action="这是主动取消操作；如需发布，请重新执行并确认。",
         )

--- a/src/publisher/xiaohongshu.py
+++ b/src/publisher/xiaohongshu.py
@@ -14,7 +14,7 @@ import os
 import time
 import tempfile
 from pathlib import Path
-from .base import BasePublisher, PublishContent, PublishResult
+from .base import BasePublisher, PublishContent, PublishResult, build_publish_failure
 
 
 # 默认占位图尺寸
@@ -163,9 +163,9 @@ class XiaohongshuPublisher(BasePublisher):
 
         # 3. 上传图片（必须，否则编辑器不出现）
         if not self._upload_image(content):
-            return PublishResult(
+            return build_publish_failure(
                 platform=self.PLATFORM_NAME,
-                success=False,
+                code="UPLOAD_FAILED",
                 message="图片上传失败，无法继续发布",
             )
 
@@ -270,4 +270,6 @@ class XiaohongshuPublisher(BasePublisher):
             platform=self.PLATFORM_NAME,
             success=False,
             message="用户跳过发布",
+            error_code="USER_CANCELLED",
+            next_action="这是主动取消操作；如需发布，请重新执行并确认。",
         )

--- a/src/publisher/zhihu.py
+++ b/src/publisher/zhihu.py
@@ -16,7 +16,7 @@
 
 import re
 import time
-from .base import BasePublisher, PublishContent, PublishResult
+from .base import BasePublisher, PublishContent, PublishResult, build_publish_failure
 
 
 class ZhihuPublisher(BasePublisher):
@@ -198,9 +198,9 @@ class ZhihuPublisher(BasePublisher):
         self.page.goto(self.PUBLISH_URL, wait_until="domcontentloaded", timeout=30000)
         time.sleep(2)
         if not self._ensure_write_page(max_attempts=4):
-            return PublishResult(
+            return build_publish_failure(
                 platform=self.PLATFORM_NAME,
-                success=False,
+                code="LOGIN_REQUIRED",
                 message="未能进入知乎写作页（可能卡在登录或安全验证）",
                 url=self.page.url,
             )
@@ -254,9 +254,9 @@ class ZhihuPublisher(BasePublisher):
         time.sleep(1)
         if not self._is_publish_button_enabled():
             print("  ✗ 发布按钮 disabled，内容可能未被编辑器识别")
-            return PublishResult(
+            return build_publish_failure(
                 platform=self.PLATFORM_NAME,
-                success=False,
+                code="PUBLISH_BLOCKED",
                 message="发布按钮未激活（已保存为草稿）",
                 url=self.page.url,
             )
@@ -270,9 +270,9 @@ class ZhihuPublisher(BasePublisher):
             try:
                 if not self._click_publish_button():
                     print("  ⚠ 未找到可用的发布按钮")
-                    return PublishResult(
+                    return build_publish_failure(
                         platform=self.PLATFORM_NAME,
-                        success=False,
+                        code="EDITOR_NOT_FOUND",
                         message="未找到可用的发布按钮",
                     )
 
@@ -321,4 +321,6 @@ class ZhihuPublisher(BasePublisher):
             success=False,
             message="用户跳过发布（已保留草稿）",
             url=self.page.url,
+            error_code="USER_CANCELLED",
+            next_action="这是主动取消操作；如需发布，请重新执行并确认。",
         )


### PR DESCRIPTION
## Summary
- Standardize publish flow output with pre-checklist (login/content length/tags/images), structured post-summary, and actionable next-step hints.
- Add structured publisher failure fields (`error_code`/`next_action`) and normalize CLI rendering of publish failures.
- Simplify `interactive` flow for non-technical users with required/optional grouping, default choices, and one-key skip for optional fields.
- Add non-technical acceptance regression script with 5 cases and integrate core 2 cases into `forge.py test` for CI.
- Add README non-technical 5-minute onboarding and troubleshooting; record acceptance baseline update policy in AIEF experience index.

## Verification
- `python3 -m py_compile forge.py src/publisher/base.py src/publisher/xiaohongshu.py src/publisher/zhihu.py src/publisher/wechat.py src/publisher/toutiao.py scripts/nontech_acceptance_regression.py`
- `python3 scripts/nontech_acceptance_regression.py`
- `python3 forge.py test`

## Issue coverage
Closes #9
Closes #10
Closes #11
Closes #12
Closes #13
Closes #14
Closes #15
Closes #16
Closes #17
Closes #18
